### PR TITLE
Added Laravel 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
+        "nunomaduro/collision": "^7.8|^8.1",
+        "larastan/larastan": "^2.9.2",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
Just updated some dependencies. Also switched from `nunomaduro/larastan` to `larastan/larastan`. Doesn't seem to be used, tho ;) 